### PR TITLE
feat: 为“面试日常”添加"all"查看所有分组的选项

### DIFF
--- a/src/views/interview/schedule/allGroups.ts
+++ b/src/views/interview/schedule/allGroups.ts
@@ -1,0 +1,2 @@
+const allGroups = Symbol('all');
+export default allGroups;

--- a/src/views/interview/schedule/components/schedules.vue
+++ b/src/views/interview/schedule/components/schedules.vue
@@ -6,7 +6,11 @@
       }}</span>
       <a-dropdown>
         <div class="cursor-pointer text-[--color-text-1] text-base">
-          <span class="mr-1"> {{ currentGroup }} </span>
+          <span class="mr-1">
+            {{
+              currentGroup === allGroups ? allGroups.description : currentGroup
+            }}
+          </span>
           <icon-down />
         </div>
         <template #content>
@@ -15,7 +19,7 @@
             :key="item"
             @click="handleGroupClick(item)"
           >
-            {{ item }}
+            {{ item === allGroups ? allGroups.description : item }}
           </a-doption>
         </template>
       </a-dropdown>
@@ -81,6 +85,7 @@ import router from '@/router';
 import { Group } from '@/constants/team';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import allGroups from '../allGroups';
 
 interface CandidateInfo {
   name: string;
@@ -96,13 +101,17 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
-const currentGroup = defineModel<Group>({
+const currentGroup = defineModel<Group | typeof allGroups>({
   required: true,
 });
 
-const groups = computed(() =>
-  Object.values(Group).filter((x) => x !== Group.Unique),
-);
+const groups = computed(() => {
+  const ret: (Group | typeof allGroups)[] = Object.values(Group).filter(
+    (x) => x !== Group.Unique,
+  );
+  ret.unshift(allGroups);
+  return ret;
+});
 
 const goManagement = () => {
   router.push({ name: 'interviewMangement' });

--- a/src/views/interview/schedule/index.vue
+++ b/src/views/interview/schedule/index.vue
@@ -25,6 +25,7 @@ import useRecruitmentStore from '@/store/modules/recruitment';
 import dayjs from 'dayjs';
 import calender from './components/calendar.vue';
 import schedules from './components/schedules.vue';
+import allGroups from './allGroups';
 
 // 格式化日期
 const formatToday = (date: Date) => {
@@ -55,7 +56,7 @@ function Duration(start: Date, end: Date) {
 }
 
 provide('formatToday', formatToday);
-const currentGroup = ref(Group.Web);
+const currentGroup = ref<Group | typeof allGroups>(allGroups);
 const selectedDate = ref<string>('2024-01-01');
 const recStore = useRecruitmentStore();
 
@@ -105,7 +106,12 @@ const filteredApps = computed(() =>
         step === 'GroupInterview'
           ? selectedDate.value === formatDate(groupStartDate)
           : selectedDate.value === formatDate(teamStartDate);
-      const isGroup = group === currentGroup.value;
+      let isGroup: boolean;
+      if (currentGroup.value === allGroups) {
+        isGroup = true;
+      } else {
+        isGroup = group === currentGroup.value;
+      }
       return isStep && isGroup && isTime;
     },
   ),


### PR DESCRIPTION
feat: 为“面试日常”添加"all"查看所有分组的选项，原型图上是有的，希望这样能让这个页面不那么反人类；不过目前的实现可能不太规范，不过我觉得挺好的
